### PR TITLE
Patch for Redmine 5.x / Rails 6.x compatibility

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,5 +1,5 @@
 require 'redmine'
-
+$LOAD_PATH.unshift "#{File.dirname(__FILE__)}/lib"
 require 'project_tree/patches/projects_helper_patch'
 require 'project_tree/patches/projects_controller_patch'
 
@@ -8,7 +8,7 @@ Redmine::Plugin.register :project_tree do
 	name 'Project Tree plugin'
 	author 'Uwe Heber, Matthias Petermann'
 	description 'This is a Redmine plugin which will turn the projects page into a tree view'
-	version '1.0.3'
+	version '2.0.0'
 	url 'https://github.com/UweHeber/redmine-project-tree-plugin'
 	author_url 'http://heber.it/about, http://petermann-it.de'
 end

--- a/lib/project_tree/patches/projects_controller_patch.rb
+++ b/lib/project_tree/patches/projects_controller_patch.rb
@@ -45,4 +45,4 @@ module ProjectTree
     end
 end
 
-ProjectsController.send(:include, ProjectTree::Patches::ProjectsControllerPatch)
+ProjectsController.send(:include, ::ProjectTree::Patches::ProjectsControllerPatch)

--- a/lib/project_tree/patches/projects_helper_patch.rb
+++ b/lib/project_tree/patches/projects_helper_patch.rb
@@ -55,4 +55,4 @@ module ProjectTree
     end
 end
 
-ProjectsHelper.send(:include, ProjectTree::Patches::ProjectsHelperPatch)
+ProjectsHelper.send(:include, ::ProjectTree::Patches::ProjectsHelperPatch)


### PR DESCRIPTION
Hi Uwe, I adjusted patch loading mechanism for compatibility with Redmine 5.x / Rails 6.x. With this small changes in place, I was able to successfully validate the functionality. I did not perform tests with older Redmine versions. I expect this is very likely to break compatibility with older Redmine versions. Therefore I increased the major version in my fork 2.0.0. 

Kind regards
Matthias